### PR TITLE
log.proto: add LeaderInfo; add node_group_leader_info to WriteLogResponse

### DIFF
--- a/log.proto
+++ b/log.proto
@@ -265,6 +265,7 @@ message WriteLogRequest {
 message LeaderInfo {
   int64 term = 1;
   bytes ip = 2;
+  uint32 port = 3;
 }
 
 message WriteLogResponse {


### PR DESCRIPTION
Related PR:
https://github.com/eloqdata/tx_service/pull/134
https://github.com/eloqdata/eloq_log_service/pull/18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Write responses now include current leader details for each node group (leader term, IP, and port), improving cluster visibility and enabling clients to route requests to the right node faster.
  - Enhances observability of leadership changes across node groups, aiding diagnostics and reducing latency during leader transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->